### PR TITLE
Add in codepotato because potatoes

### DIFF
--- a/sites.js
+++ b/sites.js
@@ -9,5 +9,6 @@ let sites = [
     { name: "Teevio", url: 'https://teev.io'},
     { name: "Jamie Howard", url: 'https://jamiehoward.co'},
     { name: "Luigi Battaglioli", url: 'https://theluigi.com'},
-    { name: "Matt Lantz", url: 'https://mattlantz.ca'}
+    { name: "Matt Lantz", url: 'https://mattlantz.ca'},
+    { name: "Codepotato", url: 'https://codepotato.co.uk'},
 ]


### PR DESCRIPTION
Potatoes. 

I've traded under the moniker codepotato because potatoes are massively under-rated, obviously. 

If you add us to the site, you'll feature exclusively in our hall of weird fame, and the team here will be asked politely (then fired if they don't) to bow when passing your photo. 

In all seriousness, we work in a boring industry (financial services) but have potato in our name so that's kinda weird, right? 