### PR TITLE
Fix issue with URL lookups

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -8,7 +8,7 @@ function getReferringSite() {
     if (urlParams.has('referrer')) {
         return 'https://' + urlParams.get('referrer');
     } else if (document.referrer !== '') {
-        return document.referrer.replace(/\/$/, "")
+        return 'https://' + new URL(document.referrer).host
     }
 
     return getRandomSite()


### PR DESCRIPTION
URL lookups from detected referrers failed because they included paths and query params - they should only use https://<hostname>. I think this fixes it but not sure how to do a quick test.

Note: I don't think this works in IE. 🤷‍♂️