### PR TITLE
Replace double question mark operator with double pipe

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -16,7 +16,7 @@ function getReferringSite() {
 
 function getNextSite() {
     var index = sites.findIndex(element => element.url === getReferringSite())
-    var site = sites[index + 1] ?? sites[0]
+    var site = sites[index + 1] || sites[0]
 
     return site.url
 }


### PR DESCRIPTION
The double question mark operator is a syntax error in safari (running 12.something here) -- i think a double pipe is safe enough probably?

p.s. <3 this webring.