### PR TITLE
Fix sites.js list

### DIFF
--- a/sites.js
+++ b/sites.js
@@ -134,8 +134,8 @@ let sites = [
       name: "Wyatt Castaneda",
       url: 'https://wyattblogs.com/',
       because: "Blogs are like trail mix, little of this, little of that."
-    }
-     {
+    },
+    {
       name: "Vern's World",
       url: 'https://verns.world/',
       because: "I love the old internet and want it to go back that way ever so much. Also because my website kicks ass."


### PR DESCRIPTION
Second to last item was missing a trailing comma, resulting in an invalid data structure

The site is currently broken as-is (as are the next/prev/random links)

<img width="1347" alt="Screenshot 2020-10-12 at 19 22 17" src="https://user-images.githubusercontent.com/9140811/95769252-43761b80-0cc0-11eb-9755-1a9548bb8471.png">
